### PR TITLE
Synced basic.md with examples repo

### DIFF
--- a/docs/arvo/basic.md
+++ b/docs/arvo/basic.md
@@ -13,28 +13,68 @@ possible. To get there, we have to quickly cover some of the fundamentals of
 first [Project Euler](https://projecteuler.net/) problem and
 [fizzbuzz](https://en.wikipedia.org/wiki/Fizz_buzz).
 
-To run this code, you'll need an urbit, and will have to copy the [examples
-repo](https://github.com/urbit/examples) into it.
+To run this code, you'll need an urbit, and will have to either sync or copy the
+[examples repo](https://github.com/urbit/examples) into it.
 
-If you haven't installed urbit yet, check out the [installation
-instructions](/docs/using/install). Once urbit is installed, take a look at the
-[basic operation](/docs/using/admin) of your urbit.
+## Installation
 
-If you haven't copied in the examples repo, running the following commands from
-your urbit directory should do the trick:
+First, you'll need a running urbit. Follow our urbit.org [install 
+instructions](https://urbit.org/docs/using/install), then 
+[setup](https://urbit.org/docs/using/setup) and urbit.
 
-Make sure you've mounted your `%home` desk:
+Follow the *Network install* below if your urbit is running on the live network 
+(comets are usually best for development). Follow the *Local install* instead 
+if you're on a 
+[fake ship](https://urbit.org/fora/posts/~2017.1.5..21.31.04..20f3~/) or are 
+otherwise experiencing problems with the network install.  
 
-    ~fintud-macrep:dojo> |mount %
+### Network install
 
-Then, copy the example into it
+In your urbit's `:dojo`, run the command:
 
-    $ cp -r {urbit-examples}/gall/*/* {your-pier}/home/
-    $ cp -r {urbit-examples}/dojo/*/* {your-pier}/home/
+    ~your-urbit:dojo> |sync %examples ~ropmev-pocseb %examples
+
+Depending on network traffic, this initial merge and sync could take anywhere
+between thirty seconds to several minutes. Upon a successful sync you'll see the
+output:
+
+    sync succeeded from %examples on ~ropmev-pocseb to %examples
+
+In which case, next run the commands:
+
+    ~your-urbit:dojo> =dir /=examples=
+    ~your-urbit:dojo/examples> |serve %/web
+    ~your-urbit:dojo/examples> |mount %
+
+If your sync isn't succeeding after a few minutes for whatever reason, run
+`|cancel %examples` in your `:dojo` and follow the local install below instead.
+
+### Local install
+
+In your urbit's `:dojo`:
+
+    ~your-urbit:dojo> |merge %examples our %base, =gem %init
+    ~your-urbit:dojo> =dir /=examples=
+    ~your-urbit:dojo/examples> |serve %/web
+    ~your-urbit:dojo/examples> |mount %
+
+If `~your-urbit` was installed at `/urbit/path` on your Unix machine, you can
+now find your `%examples` desk at the path `/urbit/path/your-urbit/examples`.
+
+Lastly, in Unix, clone this repo somewhere and copy in the `examples` files to
+your urbit's new mounted `%examples` desk. You can run the following shell
+commands (*replacing your urbit's examples desk path as necessary*):
+
+    $ git clone https://github.com/urbit/examples
+    $ for dir in {app,gen,lib,mar,sec,sur,web}; do cp -r ./examples/$dir* /urbit/path/your-urbit/examples; done
+
+Your `%clay` filesystem should acknowledge the newly added files.
+
+## Get started!
 
 Run an example to ensure it worked:
 
-    ~fintud-macrep:dojo> +examples-euler1
+    ~fintud-macrep:dojo> +project-euler/p1
     233.168
 
 ## Euler 1
@@ -47,42 +87,44 @@ Let's check out the code for Euler 1. First, the problem:
     Find the sum of all the multiples of 3 or 5 below 1000.
 
 Here is the hoon solution (which should be in your pier directory under
-`/gen/examples/euler1`):
+`/examples/gen/project-euler/p1`):
 
-    ::    project euler 1
-    ::    https://projecteuler.net/problem=1
-    ::  run in dojo with +examples-euler1
+    ::  Project Euler 1
+    ::  https://projecteuler.net/problem=1
     ::
-    ::::  /hoon/euler1/examples/gen
-      ::
-    :-  %say  |=  *  
+    ::  run in dojo with:
+    ::    ~your-urbit:dojo/examples> +project-euler/p1
+    ::
+    ::::  /===/gen/project-euler/p1/hoon
+      ::  
+    !:
+    ::
+    :-  %say  |=  *
     :-  %noun
     =<  (sum 1.000)
     ::
-    ::::  ~sivtyv-barnel
-      ::
     |%
     ++  three
-      |=  a/@
-      =|  b/@
-      |-  ^-  @u
+      |=  a/@ 
+      =|  b/@ 
+      |-  ^-  @u  
       ?:  (lth a b)
-        0
+        0   
       (add b $(b (add 3 b)))
     ::
     ++  five
-      |=  a/@
-      =|  b/@
+      |=  a/@ 
+      =|  b/@ 
       |-  ^-  @
       ?:  (lte a b)
-        0
+        0   
       ?:  =((mod b 3) 0)
-        $(b (add b 5))
+        $(b (add b 5)) 
       (add b $(b (add b 5)))
     ::
-    ++  sum
+    ++  sum 
       |=  a/@u
-      (add (five a) (three a))
+      (add (five a) (three a)) 
     --
 
 > Hoon is not generally whitespace sensitive, but we do have two different kinds
@@ -91,7 +133,7 @@ Here is the hoon solution (which should be in your pier directory under
 > explanation of when to use spaces vs. gaps, see the syntax section before the
 > first exercises.
 
-### Lines 1-11:
+### Lines 1-13:
 
 Any line that begins with `::` is a comment.
 
@@ -110,7 +152,7 @@ takes a specific number of children, either expressions formed by other runes or
 literals that produce their own value (some runes take *N* children, and are
 usually closed with `==`).
 
-For example, the rune `?:` from line 18 is the classic 'if-then-else' statement,
+For example, the rune `?:` from line 20 is the classic 'if-then-else' statement,
 and thus takes three children:
 
       ?:  (lth a b)           ::  if first child evals to true
@@ -141,31 +183,15 @@ See the entire naming scheme below.
 
 Using this scheme, we would pronounce `?:` as 'wutcol'.
 
-For those who prefer to use reserved words to form expressions, you can
-substitute any rune with that rune's keyword, which you can find in `++twig` in
-`/arvo/hoon.hoon`. For example, here's the code for `?:` in `++twig`:
+### Lines 14-37
 
-`{$if p/twig q/twig r/twig}                          ::  ?:  if/then/else`
-
-Instead of:
-
-    ?:(=(1 2) 'this is true' 'this is false')
-    'this is false'`
-
-You can write:
-
-    :if(=(1 2) 'this is true' 'this is false')
-    'this is false'
-
-### Lines 13-35
-
-Now let's quickly walk through this code line-by-line. Lines 13-35 are wrapped
+Now let's quickly walk through this code line-by-line. Lines 14-37 are wrapped
 in a `|%` ('[barcen](../../hoon/twig/bar-core/cen-core/)'), which produces a
 core. Cores are a fundamental datatype in Hoon, similar to a struct, class, or
 object. A core is just a map of names to any kind of code, whether it be
-functions or data. Each element in this map begins with a `++` followed by the
-name and the corresponding code. Since `|%` takes an arbitrary number of
-children, it needs to be closed with a `--`.
+functions or data. Each element, called an arm, in this map begins with a `++` 
+followed by the name and the corresponding code. Since `|%` takes an arbitrary 
+number of children, it needs to be closed with a `--`.
 
 > `++` ('luslus') is not technically a rune, since it is only used in core
 > syntax, as shown above.
@@ -175,7 +201,7 @@ Let's step into each of the three arms within our core.
 ### `++  sum`
 
     ++  sum
-      |=  a/@
+      |=  a/@u
       (add (five a) (three a))
     --
 
@@ -187,7 +213,7 @@ like a lambda in lisp. It takes two children:
 
 2.  The body of the function itself, which is executed when the function is
     called (in this case, with `(sum 1.000)`). This particular function adds the
-    results of evaluating the gates `++   five` and `++three` with each of their
+    results of evaluating the gates `++five` and `++three` with each of their
     respective input parameters set to `a`.
 
 ### ++ three


### PR DESCRIPTION
I've been working on the Arvo docs to update them to reflect updates to the examples repo from Keaton. Here's what I've done with `basic.md`:

* Replaced installation instructions with those from examples repo
* Removed `:keyword` example(s)
* Updated example Hoon with examples repo Hoon
* Updated `dojo` commands